### PR TITLE
make plots able to use Cairo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: String and binary representations of objects for several formats /
 Depends:
     R (>= 3.0.1)
 Suggests:
-    highr
+    highr, Cairo
 License: GPL-3
 LazyData: true
 Encoding: UTF-8


### PR DESCRIPTION
this improves quality:

at least here on linux, the Cairo package produces prettier PNGs than the `png` device, even when calling `png(..., type = 'cairo-png')`