### PR TITLE
Added LaTeX escapes to vectors, data.frames, matrices and lists.

### DIFF
--- a/R/repr_list.r
+++ b/R/repr_list.r
@@ -5,6 +5,7 @@
 #' 
 #' @aliases repr_html.list repr_markdown.list repr_latex.list
 #' @name repr_*.list
+#' @include utils.r
 NULL
 
 repr_list_generic <- function(
@@ -76,7 +77,7 @@ repr_markdown.list <- function(obj, ...) repr_list_generic(
 #' @name repr_*.list
 #' @export
 repr_latex.list <- function(obj, ...) repr_list_generic(
-	obj, 'latex',
+	latex.escape.names(obj), 'latex',
 	'\\item %s\n',
 	'\\item[\\$%s] %s\n',
 	'\\textbf{\\$%s} = %s',

--- a/R/repr_matrix_df.r
+++ b/R/repr_matrix_df.r
@@ -10,6 +10,7 @@
 #' 
 #' @aliases repr_html.matrix repr_html.data.frame repr_latex.matrix repr_latex.data.frame
 #' @name repr_*.matrix/data.frame
+#' @include utils.r
 NULL
 
 ellip.h <- '\u22EF'
@@ -140,9 +141,9 @@ repr_latex.matrix <- function(obj, ..., colspec = getOption('repr.matrix.latex.c
 	cols <- paste0(paste(rep(colspec$col, ncol(obj)), collapse = ''), colspec$end)
 	if (!is.null(rownames(obj)))
 		cols <- paste0(colspec$row.head, cols)
-	
+	obj <- latex.escape.names(obj)
 	r <- repr_matrix_generic(
-		obj,
+		latex.escape(obj),
 		sprintf('\\begin{tabular}{%s}\n%%s%%s\\end{tabular}\n', cols),
 		'%s\\\\\n\\hline\n', '  &', ' %s &',
 		'%s', '\t%s\\\\\n', '%s &',

--- a/R/repr_vector.r
+++ b/R/repr_vector.r
@@ -163,7 +163,7 @@ repr_latex.numeric <- repr_latex.logical
 #' @name repr_*.vector
 #' @export
 repr_latex.factor <- function(obj, ...) {
-	repr_latex.logical(latex.escape(obj), ...)
+	repr_latex.logical(latex.escape.vec(obj), ...)
 }
 
 #' @name repr_*.vector

--- a/R/repr_vector.r
+++ b/R/repr_vector.r
@@ -9,6 +9,7 @@
 #'     repr_html.logical     repr_html.integer     repr_html.complex     repr_html.numeric     repr_html.factor     repr_html.character
 #' @name repr_*.vector
 #' @include repr_list.r
+#' @include utils.r
 NULL
 
 # repr_text is defined via print
@@ -139,7 +140,7 @@ repr_markdown.character <- repr_markdown.logical
 #' @name repr_*.vector
 #' @export
 repr_latex.logical <- function(obj, ...) repr_vector_generic(
-	obj,
+	latex.escape.names(obj),  # escape vector names, regardless of class
 	'\\item %s\n',
 	'\\item[%s] %s\n',
 	'\\textbf{%s:} %s',
@@ -161,8 +162,10 @@ repr_latex.numeric <- repr_latex.logical
 
 #' @name repr_*.vector
 #' @export
-repr_latex.factor <- repr_latex.logical
+repr_latex.factor <- function(obj, ...) {
+	repr_latex.logical(latex.escape(obj), ...)
+}
 
 #' @name repr_*.vector
 #' @export
-repr_latex.character <- repr_latex.logical
+repr_latex.character <- repr_latex.factor

--- a/R/utils.r
+++ b/R/utils.r
@@ -52,6 +52,9 @@ any.latex.specials <- function(char_vec) {
 	# the object many times).
 	# This function could also be done in one regex with a bunch of groups and '|'
 	# The use of 'any' should make this function play nice with NULL names.
+	if (! inherits(char_vec, c('character', 'factor')))
+		return(FALSE)
+
 	grepl.one.special <- function(special, char_vec) {
 		return(any(grepl(special, char_vec, fixed=TRUE)))
 	}
@@ -59,4 +62,17 @@ any.latex.specials <- function(char_vec) {
 	specials_match <- vapply(names(latex.specials), grepl.one.special,
 		char_vec=char_vec, FUN.VALUE=FALSE)
 	return(any(specials_match))
+}
+
+latex.escape.vec <- function(vec) {
+	# latex.escape.vec should never change the class of its input.
+	# That seems useful, since functions like ellip.limit.arr check class.
+	stopifnot(is.vector(vec) || is.factor(vec))
+	if (any.latex.specials(vec)) {
+		if (is.factor(vec))
+			levels(vec) <- latex.escape(levels(vec))
+		else
+			vec <- latex.escape(vec) # regular character vec
+	}
+	return(vec)
 }

--- a/R/utils.r
+++ b/R/utils.r
@@ -57,6 +57,6 @@ any.latex.specials <- function(char_vec) {
 	}
 	# Search, using vapply, for each special.
 	specials_match <- vapply(names(latex.specials), grepl.one.special,
-													 char_vec=char_vec, FUN.VALUE=FALSE)
+		char_vec=char_vec, FUN.VALUE=FALSE)
 	return(any(specials_match))
 }

--- a/R/utils.r
+++ b/R/utils.r
@@ -29,3 +29,34 @@ latex.escape <- function(text) {
 	# undo superfluous escape
 	gsub('\\textbackslash\\{\\}', '\\textbackslash{}', text, fixed = TRUE)
 }
+
+latex.escape.names <- function(obj) {
+	# Depending on the object type, names, rownames and colnames may be the same or different
+	# Capture all three before changing them.
+	# Note that the resulting names may not be valid R syntax.
+	obj_names <- names(obj)
+	obj_rownames <- rownames(obj)
+	obj_colnames <- colnames(obj)
+	if (any.latex.specials(obj_names))
+		names(obj) <- latex.escape(obj_names)
+	if (any.latex.specials(obj_rownames))
+		rownames(obj) <- latex.escape(obj_rownames)
+	if (any.latex.specials(obj_colnames))
+		colnames(obj) <- latex.escape(obj_colnames)
+
+	return(obj)
+}
+
+any.latex.specials <- function(char_vec) {
+	# Use this function to avoid setting names unnecessarily (and thereby copying
+	# the object many times).
+	# This function could also be done in one regex with a bunch of groups and '|'
+	# The use of 'any' should make this function play nice with NULL names.
+	grepl.one.special <- function(special, char_vec) {
+		return(any(grepl(special, char_vec, fixed=TRUE)))
+	}
+	# Search, using vapply, for each special.
+	specials_match <- vapply(names(latex.specials), grepl.one.special,
+													 char_vec=char_vec, FUN.VALUE=FALSE)
+	return(any(specials_match))
+}

--- a/R/utils.r
+++ b/R/utils.r
@@ -69,10 +69,11 @@ latex.escape.vec <- function(vec) {
 	# That seems useful, since functions like ellip.limit.arr check class.
 	stopifnot(is.vector(vec) || is.factor(vec))
 	if (any.latex.specials(vec)) {
-		if (is.factor(vec))
+		if (is.factor(vec)) {
 			levels(vec) <- latex.escape(levels(vec))
-		else
+		} else {
 			vec <- latex.escape(vec) # regular character vec
+		}
 	}
 	return(vec)
 }


### PR DESCRIPTION
Addresses issue #10.

Other changes:
- repr_list.r, repr_matrix_df.r and repr_vector.r now source utils.r.

- utils.r now has the functions `latex.escape.names`, which takes an object and
returns a copy with latex-sanitized names, and `any.latex.specials` which
returns TRUE/FALSE for whether an input includes any special LaTeX characters.