### PR TITLE
Fixing syntax error on "if"

### DIFF
--- a/R/repr_matrix_df.r
+++ b/R/repr_matrix_df.r
@@ -49,7 +49,7 @@ ellip.limit.arr <- function(
 	if (is.data.frame(a)) {
 		# data.tables can't be indexed by column number, unless you provide the
 		# with=FALSE parameter. To avoid the hassle, just convert to a normal table.
-		if inherits(a, 'data.table')
+		if (inherits(a, 'data.table'))
 			a <- as.data.frame(x)
 		for (c in seq_len(ncol(a))) {
 			if (is.factor(a[, c])) {


### PR DESCRIPTION
This is a "blind" fix that I've written directly in the GitHub web interface. It aims to fix a syntax error when trying to install the latest development version of this package.

    > install_github('IRkernel/repr')
    Downloading GitHub repo IRkernel/repr@master
    from URL https://api.github.com/repos/IRkernel/repr/zipball/master
    […]
    * installing *source* package ‘repr’ ...
    ** R
    Error in parse(outFile) : 
      /tmp/RtmpdGY5BX/devtools7cc11efe6bbb/IRkernel-repr-a4de65c/R/repr_matrix_df.r:52:20: unexpected symbol
    51:                 # with=FALSE parameter. To avoid the hassle, just convert to a normal table.
    52:                 if inherits
                           ^
    ERROR: unable to collate and parse R files for package ‘repr’