### PR TITLE
Fixes for array indexing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,8 @@ Description: String and binary representations of objects for several formats /
 Depends:
     R (>= 3.0.1)
 Suggests:
-    highr, Cairo
+    highr, Cairo,
+    testthat
 License: GPL-3
 LazyData: true
 Encoding: UTF-8

--- a/R/repr_matrix_df.r
+++ b/R/repr_matrix_df.r
@@ -173,7 +173,10 @@ repr_latex.matrix <- function(obj, ..., colspec = getOption('repr.matrix.latex.c
 	obj <- latex.escape.names(obj)
 	
 	# escape LaTeX special characters if necessary
-	if (any(apply(obj, 2L, any.latex.specials))) {
+	need_to_excape_col <- vapply(seq_len(ncol(obj)), function(col_index) {
+			any.latex.specials(obj[, col_index])
+		}, FUN.VALUE = TRUE)
+	if (any(need_to_excape_col)) {
 		# To avoid rowname removal and dimension elimination, we replace the contents only
 		obj[] <-
 			if (is.list(obj))

--- a/R/repr_matrix_df.r
+++ b/R/repr_matrix_df.r
@@ -19,12 +19,21 @@ ellip.d <- '\u22F1'
 
 ellipses <- c(ellip.h, ellip.v, ellip.d)
 
+get.limit.index <- function(obj_dim, limit) {
+	stopifnot(obj_dim > limit)  # otherwise this function should not have been run
+	left_or_top <- seq_len(ceiling(limit / 2))
+	right_or_bottom <- seq.int(obj_dim - floor(limit / 2) + 1L, obj_dim)
+	return(list(begin=left_or_top, end=right_or_bottom)) 
+}
+
 ellip.limit.vec <- function(v, num, ellip) {
 	stopifnot(num >= 2L)
 	
-	left  <- seq_len(ceiling(num / 2))
-	right <- seq.int(length(v) - floor(num / 2) + 1L, length(v))
-	
+	lim_index <- get.limit.index(length(v), num)
+	left <- lim_index$begin
+	right <- lim_index$end
+	rm(lim_index)
+
 	# fix factors not having the appropriate levels
 	if (is.factor(v)) {
 		levels(v) <- c(levels(v), ellipses)
@@ -39,7 +48,12 @@ ellip.limit.arr <- function(
 	cols = getOption('repr.matrix.max.cols')
 ) {
 	stopifnot(rows >= 2L, cols >= 2L)
-	
+
+	# Don't worry about any of the code below if the array is already small.
+	if (rows >= nrow(a) && cols >= ncol(a)) {
+		return(a)
+	}
+
 	left   <- seq_len(ceiling(cols / 2))
 	right  <- seq.int(ncol(a) - floor(cols / 2) + 1L, ncol(a))
 	top    <- seq_len(ceiling(rows / 2))
@@ -50,7 +64,7 @@ ellip.limit.arr <- function(
 		# data.tables can't be indexed by column number, unless you provide the
 		# with=FALSE parameter. To avoid the hassle, just convert to a normal table.
 		if (inherits(a, 'data.table'))
-			a <- as.data.frame(x)
+			a <- as.data.frame(a)
 		for (c in seq_len(ncol(a))) {
 			if (is.factor(a[, c])) {
 				# Factors: add ellipses to levels
@@ -62,10 +76,14 @@ ellip.limit.arr <- function(
 		}
 	}
 	
-	if (rows >= nrow(a) && cols >= ncol(a)) {
-		return(a)
-	} else if (rows < nrow(a) && cols < ncol(a)) {
-		ehf <- factor(ellip.h, levels = ellipses)
+	if (rows < nrow(a) && cols < ncol(a)) {
+		if (is.matrix(a)) {
+			# If a is a matrix, R will coerce the factor to character and sub in 
+			# the factor *value*, not the level.  You end up with a bunch of 1s.
+			ehf <- ellip.h
+		} else {
+			ehf <- factor(ellip.h, levels = ellipses)
+		}
 		rv <- rbind(
 			cbind(a[   top, left], ehf, a[   top, right], deparse.level = 0),
 			ellip.limit.vec(rep(ellip.v, ncol(a)), cols, ellip.d),
@@ -77,19 +95,13 @@ ellip.limit.arr <- function(
 		rv <- cbind(a[, left, drop = FALSE], ellip.h, a[, right, drop = FALSE], deparse.level = 0)
 	}
 
-	if (rows < nrow(a)) {
-		# If there were no rownames before, as is often true for matrices, assign them.
-		if (is.null(rownames(rv)))
-			rownames(rv) <- c(top, ellip.v, bottom)
-		else
-			rownames(rv)[[ top[[length(top) ]] + 1L]] <- ellip.v
+	if (rows < nrow(a) && (! is.null(rownames(rv)))) {
+		# If there were no rownames before, as is often true for matrices, don't assign them.
+		rownames(rv)[[ top[[length(top) ]] + 1L]] <- ellip.v
 	}
-
-	if (cols < ncol(a)) {
-		if (is.null(colnames(rv)))
-			colnames(rv) <- c(left, ellip.h, right)
-		else
-			colnames(rv)[[left[[length(left)]] + 1L]] <- ellip.h
+	if (cols < ncol(a) && (! is.null(colnames(rv)))) {
+		# If there were no colnames before, as is often true for matrices, don't assign them.
+		colnames(rv)[[left[[length(left)]] + 1L]] <- ellip.h
 	}
 
 	rv

--- a/R/repr_matrix_df.r
+++ b/R/repr_matrix_df.r
@@ -23,23 +23,19 @@ get.limit.index <- function(obj_dim, limit) {
 	stopifnot(obj_dim > limit)  # otherwise this function should not have been run
 	left_or_top <- seq_len(ceiling(limit / 2))
 	right_or_bottom <- seq.int(obj_dim - floor(limit / 2) + 1L, obj_dim)
-	return(list(begin=left_or_top, end=right_or_bottom)) 
+	list(begin = left_or_top, end = right_or_bottom)
 }
 
 ellip.limit.vec <- function(v, num, ellip) {
 	stopifnot(num >= 2L)
-	
-	lim_index <- get.limit.index(length(v), num)
-	left <- lim_index$begin
-	right <- lim_index$end
-	rm(lim_index)
 
+	lims <- get.limit.index(length(v), num)
 	# fix factors not having the appropriate levels
 	if (is.factor(v)) {
 		levels(v) <- c(levels(v), ellipses)
 	}
 	
-	c(v[left], ellip, v[right])
+	c(v[lims$begin], ellip, v[lims$end])
 }
 
 ellip.limit.arr <- function(
@@ -173,10 +169,10 @@ repr_latex.matrix <- function(obj, ..., colspec = getOption('repr.matrix.latex.c
 	obj <- latex.escape.names(obj)
 	
 	# escape LaTeX special characters if necessary
-	need_to_excape_col <- vapply(seq_len(ncol(obj)), function(col_index) {
+	need_to_escape_col <- vapply(seq_len(ncol(obj)), function(col_index) {
 			any.latex.specials(obj[, col_index])
 		}, FUN.VALUE = TRUE)
-	if (any(need_to_excape_col)) {
+	if (any(need_to_escape_col)) {
 		# To avoid rowname removal and dimension elimination, we replace the contents only
 		obj[] <-
 			if (is.list(obj))
@@ -193,7 +189,7 @@ repr_latex.matrix <- function(obj, ..., colspec = getOption('repr.matrix.latex.c
 		' %s &')
 
 	#TODO: remove this quick’n’dirty post processing
-	gsub(' &\\', '\\', r, fixed=TRUE)
+	gsub(' &\\', '\\', r, fixed = TRUE)
 }
 
 #' @name repr_*.matrix/data.frame

--- a/R/repr_matrix_df.r
+++ b/R/repr_matrix_df.r
@@ -168,7 +168,10 @@ repr_latex.matrix <- function(obj, ..., colspec = getOption('repr.matrix.latex.c
 		cols <- paste0(colspec$row.head, cols)
 	obj <- latex.escape.names(obj)
 	
-	# escape LaTeX special characters if necessary
+	# Escape LaTeX special characters if necessary.
+	# A more R way to do this would have been "apply(obj, 2L, any.latex.specials)"
+	# but that approach calls as.matrix.data.frame, which requires sane names in
+	# each column. That's not always true, so we'll do the more round-about vapply.
 	need_to_escape_col <- vapply(seq_len(ncol(obj)), function(col_index) {
 			any.latex.specials(obj[, col_index])
 		}, FUN.VALUE = TRUE)

--- a/R/utils.r
+++ b/R/utils.r
@@ -56,11 +56,11 @@ any.latex.specials <- function(char_vec) {
 		return(FALSE)
 
 	grepl.one.special <- function(special, char_vec) {
-		return(any(grepl(special, char_vec, fixed=TRUE)))
+		return(any(grepl(special, char_vec, fixed = TRUE)))
 	}
 	# Search, using vapply, for each special.
 	specials_match <- vapply(names(latex.specials), grepl.one.special,
-		char_vec=char_vec, FUN.VALUE=FALSE)
+		char_vec = char_vec, FUN.VALUE = FALSE)
 	return(any(specials_match))
 }
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(repr)
+
+test_check("repr")

--- a/tests/testthat/test_array_manipulation.r
+++ b/tests/testthat/test_array_manipulation.r
@@ -1,0 +1,327 @@
+
+context("Array and vector truncation")
+
+suppressPackageStartupMessages(library(data.table))
+options('stringsAsFactors' = FALSE)
+
+test_that("max rows and cols are reasonable", {
+  rows <- getOption('repr.matrix.max.rows')
+  cols <- getOption('repr.matrix.max.cols')
+  
+  expect_equal(length(rows), 1L)
+  expect_equal(length(cols), 1L)
+  
+  expect_false(is.null(rows))
+  expect_false(is.na(rows))
+  expect_false(is.null(rows))
+  expect_false(is.na(rows))
+  
+  expect_true(rows >= 2L)
+  expect_true(cols >= 2L)
+  expect_true(rows < .Machine$integer.max)
+  expect_true(cols < .Machine$integer.max)
+})
+
+test_that("get.limit.index sets the right indexes", {
+  # Limit a hypothetical length-10 vector to 2.
+  lim_index <- get.limit.index(10, 2)
+  expect_equal(lim_index$begin, 1)
+  expect_equal(lim_index$end, 10)
+  
+  # Limit a hypothetical length-10 vector to 3.
+  lim_index <- get.limit.index(10, 3)
+  expect_equal(lim_index$begin, c(1, 2))
+  expect_equal(lim_index$end, 10)
+  
+  
+  # Limit a hypothetical length-10 vector to 4.
+  lim_index <- get.limit.index(10, 4)
+  expect_equal(lim_index$begin, c(1, 2))
+  expect_equal(lim_index$end, c(9, 10))
+  
+  # Limit a hypothetical length-10 vector to 9.
+  lim_index <- get.limit.index(10, 9)
+  expect_equal(lim_index$begin, c(1, 2, 3, 4, 5))
+  expect_equal(lim_index$end, c(7, 8, 9, 10))  
+})
+
+test_that("ellip.limit.vec returns correctly for numerics", {
+  ellip.h <- '\u22EF'
+  
+  test_vec <- 10:1
+  lim <- 2
+  limited_vec <- ellip.limit.vec(test_vec, lim, ellip.h)
+  expect_equal(limited_vec, c('10', ellip.h, '1'))
+
+  lim <- 5
+  limited_vec <- ellip.limit.vec(test_vec, lim, ellip.h)
+  expect_equal(limited_vec, c('10', '9', '8', ellip.h, '2', '1'))
+  
+  lim <- 6
+  limited_vec <- ellip.limit.vec(test_vec, lim, ellip.h)
+  expect_equal(limited_vec, c('10', '9', '8', ellip.h, '3', '2', '1'))
+  
+  
+  lim <- 9
+  limited_vec <- ellip.limit.vec(test_vec, lim, ellip.h)
+  expect_equal(limited_vec, c('10', '9', '8', '7', '6', ellip.h, '4', '3', '2', '1'))
+})
+
+
+test_that("ellip.limit.vec returns correctly for factors", {
+  ellip.h <- '\u22EF'
+  
+  test_vec <- factor(10:1)
+  lim <- 2
+  limited_vec <- ellip.limit.vec(test_vec, lim, ellip.h)
+  expected_vec <- c('10', ellip.h, '1')
+  expect_equal(as.character(limited_vec), expected_vec)
+
+  lim <- 5
+  limited_vec <- ellip.limit.vec(test_vec, lim, ellip.h)
+  expected_vec <- c(10, 9, 8, ellip.h, 2, 1)
+  expect_equal(as.character(limited_vec), expected_vec)
+  
+  lim <- 6
+  limited_vec <- ellip.limit.vec(test_vec, lim, ellip.h)
+  expected_vec <- c(10, 9, 8, ellip.h, 3, 2, 1)
+  expect_equal(as.character(limited_vec), expected_vec)
+  
+  lim <- 9
+  limited_vec <- ellip.limit.vec(test_vec, lim, ellip.h)
+  expected_vec <- c(10, 9, 8, 7, 6, ellip.h, 4, 3, 2, 1)
+  expect_equal(as.character(limited_vec), expected_vec)
+})
+
+
+test_that("ellip.limit.arr doesn't change arrays that are small", {
+  # Make sure the limits are reasonable before we test.
+  orig_rows_limit <- getOption('repr.matrix.max.rows')
+	orig_cols_limit <- getOption('repr.matrix.max.cols')
+  if (orig_rows_limit < 6L) {
+    options('repr.matrix.max.rows' = 6L)
+  } 
+  if (orig_cols_limit < 3L) {
+    options('repr.matrix.max.cols' = 3L)
+  }
+  
+  # Run some tests.
+  test_mat <- matrix(1:10, ncol=2)
+  test_df <- as.data.frame(test_mat)
+  test_dt <- as.data.table(test_mat)
+  limited_mat <- ellip.limit.arr(test_mat)
+  limited_df <- ellip.limit.arr(test_df)
+  limited_dt <- ellip.limit.arr(test_dt)
+  expect_equal(limited_mat, limited_mat)
+  expect_equal(limited_df,  limited_df)
+  expect_equal(limited_dt,  limited_dt)
+
+  # Reset limits
+  if (getOption('repr.matrix.max.rows') != orig_rows_limit) {
+    options('repr.matrix.max.rows' = orig_rows_limit)
+  }
+  if (getOption('repr.matrix.max.cols') != orig_cols_limit) {
+    options('repr.matrix.max.cols' = orig_cols_limit)
+  }
+})
+
+test_that("ellip.limit.arr limits arrays that are wide (but not long)", {
+  ellip.h <- '\u22EF'
+  # Make sure the limits are reasonable before we test.
+  orig_rows_limit <- getOption('repr.matrix.max.rows')
+  orig_cols_limit <- getOption('repr.matrix.max.cols')
+  if (orig_rows_limit < 6L) {
+    options('repr.matrix.max.rows' = 6L)
+  } 
+  
+  
+  test_mat <- matrix(16:1, nrow = 2L)
+  test_df <- as.data.frame(test_mat)
+  test_dt <- as.data.table(test_mat)
+  
+  # We'll test even and odd limits, sticking with small numbers to keep things sane.
+  options('repr.matrix.max.cols' = 4L)
+  limited_mat <- ellip.limit.arr(test_mat)
+  limited_df <- ellip.limit.arr(test_df)
+  limited_dt <- ellip.limit.arr(test_dt)
+  expected_mat <- matrix(c('16', '15', '14', '13', ellip.h, ellip.h, '4', '3', 
+    '2', '1'), nrow = 2L)
+  expected_df <- data.frame(V1 = c(16, 15), V2 = c(14, 13), ellips = rep(ellip.h, 2L),
+    V7 = c(4, 3), V8 = c(2, 1))
+  names(expected_df) <- c('V1', 'V2', ellip.h, 'V7', 'V8')
+  # The code, as a shortcut, just converts data.tables to data.frames.
+  #expected_dt <- as.data.table(expected_df)
+  expected_dt <- expected_df
+  expect_equal(limited_mat, expected_mat)
+  expect_equal(limited_df,  expected_df)
+  expect_equal(limited_dt,  expected_dt)
+  
+  # Repeat with an odd limit.
+  options('repr.matrix.max.cols' = 5L)
+  limited_mat <- ellip.limit.arr(test_mat)
+  limited_df <- ellip.limit.arr(test_df)
+  limited_dt <- ellip.limit.arr(test_dt)
+  expected_mat <- matrix(c('16', '15', '14', '13', '12', '11', ellip.h, ellip.h, 
+    '4', '3', '2', '1'), nrow = 2L)
+  expected_df <- data.frame(V1 = c(16, 15), V2 = c(14, 13), V3 = c(12, 11), 
+    ellips = rep(ellip.h, 2L), V7 = c(4, 3), V8 = c(2, 1))
+  names(expected_df) <- c('V1', 'V2', 'V3', ellip.h, 'V7', 'V8')
+  # The code, as a shortcut, just converts data.tables to data.frames.
+  #expected_dt <- as.data.table(expected_df)
+  expected_dt <- expected_df
+  expect_equal(limited_mat, expected_mat)
+  expect_equal(limited_df,  expected_df)
+  expect_equal(limited_dt,  expected_dt)
+  
+  
+  # Reset limits
+  if (getOption('repr.matrix.max.rows') != orig_rows_limit) {
+    options('repr.matrix.max.rows' = orig_rows_limit)
+  }
+  if (getOption('repr.matrix.max.cols') != orig_cols_limit) {
+    options('repr.matrix.max.cols' = orig_cols_limit)
+  }
+})
+
+test_that("ellip.limit.arr limits arrays that are long (but not wide)", {
+  ellip.v <- '\u22EE'
+  # Make sure the limits are reasonable before we test.
+  orig_rows_limit <- getOption('repr.matrix.max.rows')
+  orig_cols_limit <- getOption('repr.matrix.max.cols')
+  if (orig_cols_limit < 3L) {
+    options('repr.matrix.max.cols' = 3L)
+  }
+  
+  test_mat <- matrix(16:1, ncol = 2L)
+  test_df <- as.data.frame(test_mat)
+  test_dt <- as.data.table(test_mat)
+  
+  options('repr.matrix.max.rows' = 4L)
+  limited_mat <- ellip.limit.arr(test_mat)
+  limited_df <- ellip.limit.arr(test_df)
+  limited_dt <- ellip.limit.arr(test_dt)
+  expected_mat <- matrix(c('16', '15', ellip.v, '10', '9', '8', '7', ellip.v, 
+    '2', '1'), ncol = 2L)
+  expected_df <- data.frame(V1 = c('16', '15', ellip.v, '10', '9'), 
+    V2 = c('8', '7', ellip.v, '2', '1'))
+  rownames(expected_df) <- c('1', '2', ellip.v, '7', '8')
+  # The code, as a shortcut, just converts data.tables to data.frames.
+  #expected_dt <- as.data.table(expected_df)
+  expected_dt <- expected_df
+  expect_equal(limited_mat, expected_mat)
+  expect_equal(limited_df,  expected_df)
+  expect_equal(limited_dt,  expected_dt)
+  
+  # Repeat with an odd limit.
+  options('repr.matrix.max.rows' = 5L)
+  limited_mat <- ellip.limit.arr(test_mat)
+  limited_df <- ellip.limit.arr(test_df)
+  limited_dt <- ellip.limit.arr(test_dt)
+  expected_mat <- matrix(c('16', '15', '14', ellip.v, '10', '9', '8', '7', '6', 
+    ellip.v, '2', '1'), ncol = 2L)
+  expected_df <- as.data.frame(expected_mat)
+  rownames(expected_df) <- c('1', '2', '3', ellip.v, '7', '8')
+  # The code, as a shortcut, just converts data.tables to data.frames.
+  #expected_dt <- as.data.table(expected_df)
+  expected_dt <- expected_df
+  expect_equal(limited_mat, expected_mat)
+  expect_equal(limited_df,  expected_df)
+  expect_equal(limited_dt,  expected_dt)
+  
+  # Reset limits
+  if (getOption('repr.matrix.max.rows') != orig_rows_limit) {
+    options('repr.matrix.max.rows' = orig_rows_limit)
+  }
+  if (getOption('repr.matrix.max.cols') != orig_cols_limit) {
+    options('repr.matrix.max.cols' = orig_cols_limit)
+  }
+})
+
+
+test_that("ellip.limit.arr limits arrays that are long and wide", {
+  ellip.h <- '\u22EF'
+  ellip.v <- '\u22EE'
+  ellip.d <- '\u22F1'
+  ellipses <- c(ellip.h, ellip.v, ellip.d)
+  # Make sure the limits are reasonable before we test.
+  orig_rows_limit <- getOption('repr.matrix.max.rows')
+  orig_cols_limit <- getOption('repr.matrix.max.cols')
+  
+  
+  # Make a 7x7 because I want to test with limits of 4, 5 and 6. I want to test 
+  # both the normal cases and the weird case where a dimension is one less than
+  # the limit (and therefore the 'smaller' output array is actually the same dim
+  # as the original)
+  test_mat <- matrix(1:49, ncol=7)
+  test_df <- as.data.frame(test_mat)
+  test_dt <- as.data.table(test_mat)
+  
+  # We'll test with even and odd limits (but not all combinations of the two)
+  # Test with small numbers to keep things reasonable.
+  options('repr.matrix.max.rows' = 4L)
+  options('repr.matrix.max.cols' = 4L)
+  limited_mat <- ellip.limit.arr(test_mat)
+  limited_df <- ellip.limit.arr(test_df)
+  limited_dt <- ellip.limit.arr(test_dt)
+  expected_mat <- matrix(c('1', '2', ellip.v, '6', '7', '8', '9', ellip.v, '13',
+    '14', ellip.h, ellip.h, ellip.d, ellip.h, ellip.h, '36', '37',
+    ellip.v, '41', '42', '43', '44', ellip.v, '48', '49'), nrow = 5L)
+  expected_df <- as.data.frame(expected_mat)
+  expected_df[, 3] <- factor(expected_df[, 3], levels = ellipses)
+  names(expected_df) <- c('V1', 'V2', ellip.h, 'V6', 'V7')
+  rownames(expected_df) <- c('1', '2', ellip.v, '6', '7')
+  # The code, as a shortcut, just converts data.tables to data.frames.
+  #expected_dt <- as.data.table(expected_df)
+  expected_dt <- expected_df
+  expect_equal(limited_mat, expected_mat)
+  expect_equal(limited_df,  expected_df)
+  expect_equal(limited_dt,  expected_dt)
+
+  options('repr.matrix.max.rows' = 5L)
+  options('repr.matrix.max.cols' = 5L)
+  limited_mat <- ellip.limit.arr(test_mat)
+  limited_df <- ellip.limit.arr(test_df)
+  limited_dt <- ellip.limit.arr(test_dt)
+  expected_mat <- matrix(c('1', '2', '3', ellip.v, '6', '7', '8', '9', '10', 
+    ellip.v, '13', '14', '15', '16', '17', ellip.v, '20', '21', ellip.h, 
+    ellip.h, ellip.h, ellip.d, ellip.h, ellip.h, '36', '37', '38', ellip.v,'41',
+    '42', '43', '44', '45', ellip.v, '48', '49'), nrow = 6L)
+  expected_df <- as.data.frame(expected_mat)
+  expected_df[, 4] <- factor(expected_df[, 4], levels = ellipses)
+  names(expected_df) <- c('V1', 'V2', 'V3', ellip.h, 'V6', 'V7')
+  rownames(expected_df) <- c('1', '2', '3', ellip.v, '6', '7')
+  # The code, as a shortcut, just converts data.tables to data.frames.
+  #expected_dt <- as.data.table(expected_df)
+  expected_dt <- expected_df
+  expect_equal(limited_mat, expected_mat)
+  expect_equal(limited_df,  expected_df)
+  expect_equal(limited_dt,  expected_dt)
+
+  options('repr.matrix.max.rows' = 6L)
+  options('repr.matrix.max.cols' = 6L)
+  limited_mat <- ellip.limit.arr(test_mat)
+  limited_df <- ellip.limit.arr(test_df)
+  limited_dt <- ellip.limit.arr(test_dt)
+  expected_mat <- matrix(c('1', '2', '3', ellip.v, '5', '6', '7', '8', '9',
+    '10', ellip.v, '12', '13', '14', '15', '16', '17', ellip.v, '19', '20',
+    '21', ellip.h,  ellip.h, ellip.h, ellip.d, ellip.h, ellip.h, ellip.h, '29', '30', '31', ellip.v, '33', '34', '35', '36', '37', '38', ellip.v, '40', 
+    '41', '42', '43', '44', '45', ellip.v, '47', '48', '49'), nrow = 7L)
+  expected_df <- as.data.frame(expected_mat, stringsAsFactors=FALSE)
+  expected_df[, 4] <- factor(expected_df[, 4], levels = ellipses)
+  names(expected_df) <- c('V1', 'V2', 'V3', ellip.h, 'V5', 'V6', 'V7')
+  rownames(expected_df) <- c('1', '2', '3', ellip.v, '5', '6', '7')
+  # The code, as a shortcut, just converts data.tables to data.frames.
+  #expected_dt <- as.data.table(expected_df)
+  expected_dt <- expected_df
+  expect_equal(limited_mat, expected_mat)
+  expect_equal(limited_df,  expected_df)
+  expect_equal(limited_dt,  expected_dt)
+
+  # Reset limits
+  if (getOption('repr.matrix.max.rows') != orig_rows_limit) {
+    options('repr.matrix.max.rows' = orig_rows_limit)
+  }
+  if (getOption('repr.matrix.max.cols') != orig_cols_limit) {
+    options('repr.matrix.max.cols' = orig_cols_limit)
+  }
+})

--- a/tests/testthat/test_array_manipulation.r
+++ b/tests/testthat/test_array_manipulation.r
@@ -106,7 +106,7 @@ test_that("ellip.limit.arr doesn't change arrays that are small", {
   }
   
   # Run some tests.
-  test_mat <- matrix(1:10, ncol=2)
+  test_mat <- matrix(1:10, ncol = 2)
   test_df <- as.data.frame(test_mat)
   test_dt <- as.data.table(test_mat)
   limited_mat <- ellip.limit.arr(test_mat)
@@ -252,7 +252,7 @@ test_that("ellip.limit.arr limits arrays that are long and wide", {
   # both the normal cases and the weird case where a dimension is one less than
   # the limit (and therefore the 'smaller' output array is actually the same dim
   # as the original)
-  test_mat <- matrix(1:49, ncol=7)
+  test_mat <- matrix(1:49, ncol = 7)
   test_df <- as.data.frame(test_mat)
   test_dt <- as.data.table(test_mat)
   
@@ -306,7 +306,7 @@ test_that("ellip.limit.arr limits arrays that are long and wide", {
     '10', ellip.v, '12', '13', '14', '15', '16', '17', ellip.v, '19', '20',
     '21', ellip.h,  ellip.h, ellip.h, ellip.d, ellip.h, ellip.h, ellip.h, '29', '30', '31', ellip.v, '33', '34', '35', '36', '37', '38', ellip.v, '40', 
     '41', '42', '43', '44', '45', ellip.v, '47', '48', '49'), nrow = 7L)
-  expected_df <- as.data.frame(expected_mat, stringsAsFactors=FALSE)
+  expected_df <- as.data.frame(expected_mat, stringsAsFactors = FALSE)
   expected_df[, 4] <- factor(expected_df[, 4], levels = ellipses)
   names(expected_df) <- c('V1', 'V2', 'V3', ellip.h, 'V5', 'V6', 'V7')
   rownames(expected_df) <- c('1', '2', '3', ellip.v, '5', '6', '7')


### PR DESCRIPTION
- I added some tests!  #5.
- I removed the code to add superfluous row and column numbers, which was generating the incorrect indexes of #28. 
- A minor issue, but I adjusted the fix to #27; it should be `a` not `x`.
- I fixed the problem @JanSchulz was having in issue #30 by [indexing over columns](https://github.com/IRkernel/repr/compare/master...karldw:master#diff-b6e3417417b50f04e0bb37d032a64d26R176) rather than using an `apply`.  It seems to avoid the fix the error he had, but I'm sure there's a cleaner way to solve this.
