### PR TITLE
Escape latex and html special chars in repr functions

### DIFF
--- a/R/repr_list.r
+++ b/R/repr_list.r
@@ -14,10 +14,15 @@ repr_list_generic <- function(
 	enum.wrap, named.wrap = enum.wrap,
 	...,
 	numeric.item = named.item,
-	item.uses.numbers = FALSE) {
+	item.uses.numbers = FALSE,
+	escape.FUN = identity) {
 	
 	nms <- names(vec)
+	if (!is.null(nms)) {
+		nms <- escape.FUN(nms)
+	}
 	
+	# This does escaping, so no need to escape the content again
 	mapped <- lapply(vec, format2repr[[fmt]])
 	
 	if (length(mapped) == 1 && !is.null(nms)) {
@@ -57,7 +62,8 @@ repr_html.list <- function(obj, ...) repr_list_generic(
 	'<strong>$%s</strong> = %s',
 	'<ol>\n%s</ol>\n',
 	'<dl>\n%s</dl>\n',
-	numeric.item = '\t<dt>[[%s]]</dt>\n\t\t<dd>%s</dd>\n')
+	numeric.item = '\t<dt>[[%s]]</dt>\n\t\t<dd>%s</dd>\n',
+	escape.FUN = html.escape)
 
 
 
@@ -70,7 +76,8 @@ repr_markdown.list <- function(obj, ...) repr_list_generic(
 	'**$%s** = %s',
 	'%s\n\n',
 	numeric.item = '[[%s]]\n:   %s\n',
-	item.uses.numbers = TRUE)
+	item.uses.numbers = TRUE,
+	escape.FUN = html.escape)
 
 
 
@@ -83,4 +90,5 @@ repr_latex.list <- function(obj, ...) repr_list_generic(
 	'\\textbf{\\$%s} = %s',
 	enum.wrap  = '\\begin{enumerate}\n%s\\end{enumerate}\n',
 	named.wrap = '\\begin{description}\n%s\\end{description}\n',
-	numeric.item = '\\item[{[[%s]]}] %s\n')
+	numeric.item = '\\item[{[[%s]]}] %s\n',
+	escape.FUN = latex.escape)

--- a/R/repr_vector.r
+++ b/R/repr_vector.r
@@ -20,13 +20,16 @@ repr_vector_generic <- function(
 	enum.wrap, named.wrap = enum.wrap,
 	...,
 	numeric.item = named.item,
-	item.uses.numbers = FALSE) {
+	item.uses.numbers = FALSE, escape.FUN = identity) {
 	
 	nms <- names(vec)
+	if (!is.null(nms)) {
+		nms <- escape.FUN(nms)
+	}
 	if (is.character(vec) && getOption('repr.vector.quote'))
-		char.vec <- shQuote(vec)
+		char.vec <- escape.FUN(shQuote(vec))
 	else
-		char.vec <- as.character(vec)
+		char.vec <- escape.FUN(as.character(vec))
 	
 	if (length(char.vec) == 1) {
 		if (is.null(nms)) {
@@ -71,7 +74,8 @@ repr_html.logical <- function(obj, ...) repr_vector_generic(
 	'\t<dt>%s</dt>\n\t\t<dd>%s</dd>\n',
 	'<strong>%s:</strong> %s',
 	'<ol class=list-inline>\n%s</ol>\n',
-	'<dl class=dl-horizontal>\n%s</dl>\n')
+	'<dl class=dl-horizontal>\n%s</dl>\n',
+	escape.FUN = html.escape)
 
 #' @name repr_*.vector
 #' @export
@@ -108,7 +112,8 @@ repr_markdown.logical <- function(obj, ...) repr_vector_generic(
 	'%s\n:   %s',
 	'**%s:** %s',
 	'%s\n\n',
-	item.uses.numbers = TRUE)
+	item.uses.numbers = TRUE,
+	escape.FUN = html.escape)
 
 #' @name repr_*.vector
 #' @export
@@ -146,7 +151,8 @@ repr_latex.logical <- function(obj, ...) repr_vector_generic(
 	'\\textbf{%s:} %s',
 	enum.wrap  = '\\begin{enumerate*}\n%s\\end{enumerate*}\n',
 	named.wrap = '\\begin{description*}\n%s\\end{description*}\n',
-	only.named.item = '\\textbf{%s:} %s')
+	only.named.item = '\\textbf{%s:} %s',
+	escape.FUN = latex.escape)
 
 #' @name repr_*.vector
 #' @export


### PR DESCRIPTION
Bad things happen if a character vector has valid html included and the valid
html is not escaped. Same for latex...