### PR TITLE
Suppress stacktraces in repr_text

### DIFF
--- a/R/generics.r
+++ b/R/generics.r
@@ -30,7 +30,9 @@ repr_text <- function(obj, ...) UseMethod('repr_text', obj)
 #' @name repr_text
 #' @export
 repr_text.default <- function(obj, ...) {
-	paste(capture.output(print(obj)), collapse = '\n')
+	tryCatch({
+		paste(capture.output(print(obj)), collapse = '\n')
+	}, error = function(e) paste("ERROR:", e))
 }
 
 #' Representations for specific formats


### PR DESCRIPTION
Stacktraces in repr_text look bad when packages like ggplot uses the included
print to build a plot but fail due to some situation signaled by stop(). The old
result was that a user error resulted in a stacktrace deep in our repr stack. The
new result is that only the error message is shown.

Closes: https://github.com/IRkernel/repr/issues/45