### PR TITLE
Handle POSIXt like Date

### DIFF
--- a/R/repr_matrix_df.r
+++ b/R/repr_matrix_df.r
@@ -78,7 +78,7 @@ ellip.limit.arr <- function(
 			if (is.factor(a[, c])) {
 				# Factors: add ellipses to levels
 				levels(a[, c]) <- c(levels(a[, c]), ellipses)
-			} else if (inherits(a[, c], 'Date')) {
+			} else if (inherits(a[, c], 'Date') || inherits(a[, c], 'POSIXt') ) {
 				# Dates: convert to plain strings
 				a[, c] <- as.character(a[, c])
 			}


### PR DESCRIPTION
Avoids the error "character string is not in a standard unambiguous format" when displaying data frames with a POSIXt column (POSIXct or POSIXlt). This is the same problem that #19 solves for "Date" columns, but for POSIXt columns. 