### PR TITLE
repr_*.list should not represent a structure

### DIFF
--- a/R/repr_list.r
+++ b/R/repr_list.r
@@ -61,40 +61,48 @@ repr_list_generic <- function(
 
 #' @name repr_*.list
 #' @export
-repr_html.list <- function(obj, ...) repr_list_generic(
-	obj, 'html',
-	'\t<li>%s</li>\n',
-	'\t<dt>$%s</dt>\n\t\t<dd>%s</dd>\n',
-	'<strong>$%s</strong> = %s',
-	'<ol>\n%s</ol>\n',
-	'<dl>\n%s</dl>\n',
-	numeric.item = '\t<dt>[[%s]]</dt>\n\t\t<dd>%s</dd>\n',
-	escape.FUN = html.escape)
+repr_html.list <- function(obj, ...) {
+	if (length(class(obj)) > 1) return(NextMethod())
+	repr_list_generic(
+		obj, 'html',
+		'\t<li>%s</li>\n',
+		'\t<dt>$%s</dt>\n\t\t<dd>%s</dd>\n',
+		'<strong>$%s</strong> = %s',
+		'<ol>\n%s</ol>\n',
+		'<dl>\n%s</dl>\n',
+		numeric.item = '\t<dt>[[%s]]</dt>\n\t\t<dd>%s</dd>\n',
+		escape.FUN = html.escape)
+}
+
+
+#' @name repr_*.list
+#' @export
+repr_markdown.list <- function(obj, ...) {
+	if (length(class(obj)) > 1) return(NextMethod())
+	repr_list_generic(
+		obj, 'markdown',
+		'%s. %s\n',
+		'$%s\n:   %s\n',
+		'**$%s** = %s',
+		'%s\n\n',
+		numeric.item = '[[%s]]\n:   %s\n',
+		item.uses.numbers = TRUE,
+		escape.FUN = html.escape)
+}
 
 
 
 #' @name repr_*.list
 #' @export
-repr_markdown.list <- function(obj, ...) repr_list_generic(
-	obj, 'markdown',
-	'%s. %s\n',
-	'$%s\n:   %s\n',
-	'**$%s** = %s',
-	'%s\n\n',
-	numeric.item = '[[%s]]\n:   %s\n',
-	item.uses.numbers = TRUE,
-	escape.FUN = html.escape)
-
-
-
-#' @name repr_*.list
-#' @export
-repr_latex.list <- function(obj, ...) repr_list_generic(
-	obj, 'latex',
-	'\\item %s\n',
-	'\\item[\\$%s] %s\n',
-	'\\textbf{\\$%s} = %s',
-	enum.wrap  = '\\begin{enumerate}\n%s\\end{enumerate}\n',
-	named.wrap = '\\begin{description}\n%s\\end{description}\n',
-	numeric.item = '\\item[{[[%s]]}] %s\n',
-	escape.FUN = latex.escape)
+repr_latex.list <- function(obj, ...) {
+	if (length(class(obj)) > 1) return(NextMethod())
+	repr_list_generic(
+		obj, 'latex',
+		'\\item %s\n',
+		'\\item[\\$%s] %s\n',
+		'\\textbf{\\$%s} = %s',
+		enum.wrap  = '\\begin{enumerate}\n%s\\end{enumerate}\n',
+		named.wrap = '\\begin{description}\n%s\\end{description}\n',
+		numeric.item = '\\item[{[[%s]]}] %s\n',
+		escape.FUN = latex.escape)
+}

--- a/tests/testthat/test_lists.r
+++ b/tests/testthat/test_lists.r
@@ -1,0 +1,14 @@
+context('lists')
+
+options(stringsAsFactors = FALSE)
+
+test_that('lists must be the only class', {
+	inp = structure("something", class=c("list", "A"))
+	expect_equal(repr_html(inp), NULL)
+	expect_equal(repr_markdown(inp), NULL)
+	expect_equal(repr_latex(inp), NULL)
+	inp = structure("something", class=c("A", "list"))
+	expect_equal(repr_html(inp), NULL)
+	expect_equal(repr_markdown(inp), NULL)
+	expect_equal(repr_latex(inp), NULL)
+})


### PR DESCRIPTION
Currently we have a problem for objects like gvis, which are both `gvis` and `list` -> implementing repr_text will then return the list representation for the the other formats.

```R
> library(repr)
> repr_html(structure("something", class=c("list", "A")))
[1] "<ol>\n\t<li>\"something\"</li>\n</ol>\n"
```

Change all `repr_*.list` functions so that they check if the class of the structure is list only or has other class names and only return the representation in case it's the only class name.

Fixes the problem noticed in https://github.com/mages/googleVis/pull/39/files/3af930555502fecbe70e23e748f300216c5f7796#r66951572