### PR TITLE
Use only already included latex envs in latex reprs

### DIFF
--- a/R/options.r
+++ b/R/options.r
@@ -40,6 +40,9 @@
 #' \item{\code{repr.function.highlight}}{
 #'  Use the \code{highr} package to insert highlighting instructions into the code? Needs that package to be installed. (default: FALSE)
 #' }
+#' \item{\code{repr.function.highlightlatex}}{
+#'  Use the the latex package \code{minted} to higlight functions if \code{repr.function.highlight} is \code{FALSE}? Needs that latex package to be loaded in the tex file (default: FALSE)
+#' }
 #' 
 #' }
 #'
@@ -64,7 +67,8 @@ class_defaults <- list(
 	repr.matrix.max.rows = 60,
 	repr.matrix.max.cols = 20,
 	repr.matrix.latex.colspec = list(row.head = 'r|', col = 'l', end = ''),
-	repr.function.highlight = FALSE)
+	repr.function.highlight = FALSE,
+	repr.function.highlightlatex = FALSE)
 
 #' @name repr-options
 #' @export

--- a/R/package.r
+++ b/R/package.r
@@ -1,9 +1,7 @@
 #' The repr package
 #' 
 #' @details
-#' The LaTeX repr of vectors needs \code{\\usepackage[inline]{enumitem}}
-#' 
-#' The LaTeX repr of functions with the \code{repr.function.highlight} option set to FALSE needs \code{\\usepackage{minted}}
+#' The LaTeX repr of functions with the \code{repr.function.highlight} option set to \code{FALSE} and the \code{repr.function.highlightlatex} option set to \code{TRUE} needs \code{\\usepackage{minted}}
 #' 
 #' @seealso \link{repr}, \link{repr-options}, \link{repr-generics}, \link{repr_text}
 #' 

--- a/R/repr_function.r
+++ b/R/repr_function.r
@@ -34,7 +34,11 @@ repr_html.function <- function(obj, highlight = getOption('repr.function.highlig
 #' @name repr_*.function
 #' @export
 repr_latex.function <- function(obj, highlight = getOption('repr.function.highlight'), ...) {
-	minted.wrap <- '\\begin{minted}{r}\n%s\n\\end{minted}'
+	if (getOption('repr.function.highlightlatex')) {
+		minted.wrap <- '\\begin{minted}{r}\n%s\n\\end{minted}'
+	} else {
+		minted.wrap <- '\\begin{Verbatim}[commandchars=\\\\\\{\\}]\n%s\n\\end{Verbatim}'
+	}
 	repr_function_generic(obj, 'latex', latex.escape, '%s', minted.wrap, highlight, ...)
 }
 

--- a/R/repr_vector.r
+++ b/R/repr_vector.r
@@ -149,8 +149,8 @@ repr_latex.logical <- function(obj, ...) repr_vector_generic(
 	'\\item %s\n',
 	'\\item[%s] %s\n',
 	'\\textbf{%s:} %s',
-	enum.wrap  = '\\begin{enumerate*}\n%s\\end{enumerate*}\n',
-	named.wrap = '\\begin{description*}\n%s\\end{description*}\n',
+	enum.wrap  = '\\begin{enumerate}\n%s\\end{enumerate}\n',
+	named.wrap = '\\begin{description}\n%s\\end{description}\n',
 	only.named.item = '\\textbf{%s:} %s',
 	escape.FUN = latex.escape)
 

--- a/man/repr-options.Rd
+++ b/man/repr-options.Rd
@@ -5,7 +5,7 @@
 \alias{repr-options}
 \alias{repr_option_defaults}
 \title{repr options}
-\format{An object of class \code{list} of length 13.}
+\format{An object of class \code{list} of length 14.}
 \usage{
 repr_option_defaults
 }
@@ -51,6 +51,9 @@ Setting all options set to \code{NULL} are reset to defaults when reloading the 
 }
 \item{\code{repr.function.highlight}}{
  Use the \code{highr} package to insert highlighting instructions into the code? Needs that package to be installed. (default: FALSE)
+}
+\item{\code{repr.function.highlightlatex}}{
+ Use the the latex package \code{minted} to higlight functions if \code{repr.function.highlight} is \code{FALSE}? Needs that latex package to be loaded in the tex file (default: FALSE)
 }
 
 }

--- a/man/repr-package.Rd
+++ b/man/repr-package.Rd
@@ -8,9 +8,7 @@
 The repr package
 }
 \details{
-The LaTeX repr of vectors needs \code{\\usepackage[inline]{enumitem}}
-
-The LaTeX repr of functions with the \code{repr.function.highlight} option set to FALSE needs \code{\\usepackage{minted}}
+The LaTeX repr of functions with the \code{repr.function.highlight} option set to \code{FALSE} and the \code{repr.function.highlightlatex} option set to \code{TRUE} needs \code{\\usepackage{minted}}
 }
 \seealso{
 \link{repr}, \link{repr-options}, \link{repr-generics}, \link{repr_text}

--- a/tests/testthat/test_escaping.r
+++ b/tests/testthat/test_escaping.r
@@ -32,10 +32,10 @@ test_that('simple HTML escaping works', {
 test_that('LaTeX escaping in vectors works', {
 	expect_equivalent_string(repr_latex('['), "'{[}'")
 	expect_equivalent_string(repr_latex(c('[', '|')),
-"\\begin{enumerate*}
+"\\begin{enumerate}
 \\item '{[}'
 \\item '\\textbar{}'
-\\end{enumerate*}
+\\end{enumerate}
 ")
 })
 


### PR DESCRIPTION
Unfortunately, we can't really influence what the notebook or better nbconvert
uses to include in the tex file and so set the defaults to something which works
out of the box.

Closes: https://github.com/IRkernel/IRkernel/issues/331