### PR TITLE
Update repr_help_files_with_topic.r

### DIFF
--- a/R/repr_help_files_with_topic.r
+++ b/R/repr_help_files_with_topic.r
@@ -8,20 +8,26 @@
 #' @name repr_*.help_files_with_topic
 NULL
 
-fetch_rd_db <- getFromNamespace('fetchRdDB', 'tools')
+
 
 # copy of utils:::.getHelpFile, necessary because CRAN doesn’t like us using :::
-get_help_file <- function(file) {
+get_help_file <- function(file)
+{
 	path <- dirname(file)
 	dirpath <- dirname(path)
-	if (!file.exists(dirpath))
-		stop(sprintf('invalid %s argument', sQuote('file')))
+	if(!file.exists(dirpath))
+		stop(gettextf("invalid %s argument", sQuote("file")), domain = NA)
 	pkgname <- basename(dirpath)
-	rd_db <- file.path(path, pkgname)
-	if (!file.exists(paste(rd_db, 'rdx', sep = '.')))
-		stop(sprintf('package %s exists but was not installed under R >= 2.10.0 so help cannot be accessed', sQuote(pkgname)))
-	fetch_rd_db(rd_db, basename(file))
+	RdDB <- file.path(path, pkgname)
+	if(!file.exists(paste(RdDB, "rdx", sep = ".")))
+		stop(gettextf("package %s exists but was not installed under R >= 2.10.0 so help cannot be accessed", sQuote(pkgname)), domain = NA)
+	# Alternative position for tools may neeed to be specified as in renjin build fails with "ERROR: Object 'fetchRdDB' not found"
+	pos <- -1
+	fetch_rd_db <- getFromNamespace('fetchRdDB', 'tools', pos)
+	fetch_rd_db(RdDB, basename(file))
 }
+
+
 
 #' @importFrom utils capture.output
 #' @importFrom tools Rd2HTML


### PR DESCRIPTION
I'm attempting to get repr to build with renjin, hoped that moving the getFromNamespace, and updating the function using the .getHelpFile from the current R source would help.