### PR TITLE
Fix html filter to also work with R 4.1.1 html

### DIFF
--- a/R/repr_help_files_with_topic.r
+++ b/R/repr_help_files_with_topic.r
@@ -48,8 +48,8 @@ repr_help_files_with_topic_generic <- function(obj, Rd2_) {
 	output <- capture.output(Rd2_(rd, package = pkgname, outputEncoding = 'UTF-8'))
 	
 	if (identical(Rd2_, Rd2HTML)) {
-		head.end.idx <- which(output == '</head><body>')
-		body.end.idx <- which(output == '</body></html>')
+		head.end.idx <- which(startsWith(output, '</head><body>'))
+		body.end.idx <- which(endsWith(output, '</body></html>'))
 		rm.idx <- c(seq_len(head.end.idx), body.end.idx)
 		
 		output <- output[-rm.idx]


### PR DESCRIPTION
Closes #143 

This PR makes the html filtering more robust so that it could still work with R 4.1.1 html files.