### PR TITLE
Added functionality to set the font family for the Cairo device

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,8 @@ Suggests:
     Cairo,
     stringr,
     testthat (>= 3.0.0),
-    leaflet
+    leaflet,
+    systemfonts
 Enhances:
     data.table,
     tibble,

--- a/R/repr_recordedplot.r
+++ b/R/repr_recordedplot.r
@@ -1,4 +1,14 @@
 is_cairo_installed <- function() requireNamespace('Cairo', quietly = TRUE)
+is_systemfonts_installed <- function() requireNamespace('systemfonts', quietly = TRUE)
+
+set_cairo_fonts <- function(family) {
+	Cairo::CairoFonts(
+                regular = paste0(family, ":style=", systemfonts::font_info(family)$style),
+                bold = paste0(family, ":style=", systemfonts::font_info(family, bold = TRUE)$style),
+                italic = paste0(family, ":style=", systemfonts::font_info(family, italic = TRUE)$style),
+                bolditalic = paste0(family, ":style=", systemfonts::font_info(family, bold = TRUE, italic = TRUE)$style),
+        )
+}
 
 # checking capability of X11 is slow, the short circult logic avoids
 # this if any other devices are found.
@@ -35,7 +45,7 @@ plot_title <- function(p, default = NULL) {
 #' @param antialias  Which kind of antialiasing to use for for lines and text? 'gray', 'subpixel' or 'none'? (default: gray)
 #' @param res  For PNG and JPEG, specifies the PPI for rasterization (default: 120)
 #' @param quality  For JPEG, determines the compression quality in \% (default: 90)
-#' @param family  Font family for SVG and PDF. 'sans', 'serif', 'mono' or a specific one (default: sans)
+#' @param family  Font family for PNG, SVG and PDF. 'sans', 'serif', 'mono' or a specific one (default: sans)
 #' @param ...  ignored
 #' 
 #' @examples
@@ -85,12 +95,16 @@ repr_png.recordedplot <- function(obj,
 	antialias = getOption('repr.plot.antialias'),
 	#special
 	res       = getOption('repr.plot.res'),
+        family = getOption('repr.plot.family'),
 ...) {
 	if (!is_cairo_installed() && !check_capability('png')) return(NULL)
 	
 	dev.cb <- function(tf)
-		if (is_cairo_installed())
+		if (is_cairo_installed()) {
+                        if (is_systemfonts_installed())
+                                set_cairo_fonts(family)
 			Cairo::Cairo(width, height, tf, 'png', pointsize, bg, 'transparent', 'in', res)
+                }
 		else
 			png(tf, width, height, 'in', pointsize, bg, res, antialias = antialias)
 	


### PR DESCRIPTION
This PR partly solves https://github.com/IRkernel/IRkernel/issues/604 .

As suggested in that issue, fonts for axes labels sometimes appear to have poor resolution. To resolve this, it is suggested in that issue to use the `Cairo` device, by setting `options(bitmapType='Cairo')` in the startup `argv` for the kernel (i.e. in the `kernel.json`).

This does indeed make sure that the `Cairo` device is used from that point onward. However, it will still use the default font. In case that is a (low-resolution) X11 font, the resulting axes labels still show the poor resolution. The solution is to use a vector-type font, such as `sans`. The problem is that for `png` plot types with the `Cairo` device, the `repr.font.family` is ignored.

This PR makes sure that the font family specified in `repr.font.family` is indeed set to the `Cairo` devices.

I already suggested the change [a long time ago](https://github.com/IRkernel/IRkernel/issues/604#issuecomment-737923862) but never found the time to make the change, test it, and PR it... In that thread, I proposed this approach to @flying-sheep [who also considered it a good approach](https://github.com/IRkernel/IRkernel/issues/604#issuecomment-739243393).

For me, with this PR, I can now do 

```
options(repr.plot.width = 10, repr.plot.height = 8, repr.plot.res=96, repr.plot.family='FreeMono')

ggplot(iris) + geom_point(aes(Sepal.Width, Petal.Width)) + cowplot::theme_cowplot(
    font_size=25)
```
and get:
![image](https://user-images.githubusercontent.com/33718780/134004155-ac06c169-f526-43bc-9ae9-dbe29554bdf9.png)
While with
```
options(repr.plot.family='LiberationMono')
ggplot(iris) + geom_point(aes(Sepal.Width, Petal.Width)) + cowplot::theme_cowplot(
    font_size=25)
```
I get 
![image](https://user-images.githubusercontent.com/33718780/134004240-6a1a8f67-3d26-4e40-9b75-dea19fc372c6.png)
