### PR TITLE
use list2DF to create a list-column data.frame

### DIFF
--- a/R/repr_matrix_df.r
+++ b/R/repr_matrix_df.r
@@ -70,7 +70,11 @@ arr_part_unpack_tbl <- function(tbl) {
       names(res) <- paste0(prefix, '$', names(res))
       return(res)
     } else {
-      res <- data.frame(col)
+      if(is.list(col)) {
+        res <- list2DF(list(col))
+      } else {
+        res <- data.frame(col)
+      }
       names(res) <- prefix
       return(res)
     }

--- a/tests/testthat/test_repr_array_df.r
+++ b/tests/testthat/test_repr_array_df.r
@@ -1,5 +1,7 @@
 options(stringsAsFactors = FALSE)
 
+has_dt <- requireNamespace('data.table', quietly = TRUE)
+has_tibble <- requireNamespace('tibble', quietly = TRUE)
 
 test_that('empty data.frames work', {
 	expect_identical(repr_html(data.frame()), '')
@@ -179,4 +181,26 @@ test_that('nested data.frames can be displayed', {
 	repr_markdown(outer)
 	repr_text(outer)
 	succeed()
+})
+
+test_that('data.frame with list columns can be displayed', {
+	df <- list2DF(list(a=1, b=list(1:2)))
+	expected <- '<table class="dataframe">
+<caption>A data.frame: 1 × 2</caption>
+<thead>
+\t<tr><th scope=col>a</th><th scope=col>b</th></tr>
+\t<tr><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;list&gt;</th></tr>
+</thead>
+<tbody>
+\t<tr><td>1</td><td>1, 2</td></tr>
+</tbody>
+</table>
+'
+	expect_identical(repr_html(df), expected)
+	if(has_tibble) {
+		expect_identical(repr_html(tibble::as_tibble(df)), sub('data\\.frame','tibble',expected))
+	}
+	if(has_dt) {
+		expect_identical(repr_html(data.table::as.data.table(df)), sub('data\\.frame','data.table',expected))
+	}
 })


### PR DESCRIPTION

Hello, this is a fix for printing tibbles with list columns.

currently this fails:
```R
> head(dplyr::starwars,3)
ERROR while rich displaying an object: Error in (function (..., row.names = NULL, check.rows = FALSE, check.names = TRUE, : arguments imply differing number of rows: 5, 6, 7, 4
```

this happens because the `tbl_col_format` function is trying to create a single column data.frame with a list, but list columns on base R are tricky:

```R
> data.frame(list(a=1:3, b=list(1:1, 1:2, 1:3)))
Error in (function (..., row.names = NULL, check.rows = FALSE, check.names = TRUE,  :
  arguments imply differing number of rows: 1, 2, 3
```

you need to use the `list2DF` function instead:

```R
> list2DF(list(a=1:3, b=list(1:1, 1:2, 1:3)))
  a       b
1 1       1
2 2    1, 2
3 3 1, 2, 3
```