### PR TITLE
Use drop=FALSE to avoid losing dimension in double-elided case

### DIFF
--- a/R/repr_matrix_df.r
+++ b/R/repr_matrix_df.r
@@ -43,8 +43,10 @@ arr_partition <- function(a, rows, cols) {
 	# assign a list of parts that can be coerced to strings
 	if (!is.null(part_r) && !is.null(part_c)) {
 		structure(list(
-			ul = a[part_r$start, part_c$start], ll = a[part_r$end, part_c$start],
-			ur = a[part_r$start, part_c$end  ], lr = a[part_r$end, part_c$end  ]),
+			ul = a[part_r$start, part_c$start, drop = FALSE],
+			ll = a[part_r$end  , part_c$start, drop = FALSE],
+			ur = a[part_r$start,   part_c$end, drop = FALSE],
+			lr = a[part_r$end  ,   part_c$end, drop = FALSE]),
 		omit = 'both')
 	} else if (!is.null(part_r)) {
 		structure(list(

--- a/tests/testthat/test_repr_array_df.r
+++ b/tests/testthat/test_repr_array_df.r
@@ -206,7 +206,7 @@ test_that('data.frame with list columns can be displayed', {
 })
 
 test_that('forced-narrow inputs work', {
-	withr::local_options(repr.matrix.max.rows = 2L, repr.matrix.max.cols = 2L)
+	withr::local_options(list(repr.matrix.max.rows = 2L, repr.matrix.max.cols = 2L))
 	df <- data.frame(a = 1:3, b = 4:6, c = 7:9)
 	expect_silent(repr_text(df))
 	expect_identical(

--- a/tests/testthat/test_repr_array_df.r
+++ b/tests/testthat/test_repr_array_df.r
@@ -204,3 +204,25 @@ test_that('data.frame with list columns can be displayed', {
 		expect_identical(repr_html(data.table::as.data.table(df)), sub('data\\.frame','data.table',expected))
 	}
 })
+
+test_that('forced-narrow inputs work', {
+	withr::local_options(repr.matrix.max.rows = 2L, repr.matrix.max.cols = 2L)
+	df <- data.frame(a = 1:3, b = 4:6, c = 7:9)
+	expect_silent(repr_text(df))
+	expect_identical(
+		# Scrub non-ASCII characters to make the test platform-agnostic.
+		gsub("[^a-zA-Z0-9.&;<>= '\"/:\n\t]", "*", repr_html(df)),
+		"<table class=\"dataframe\">
+<caption>A data.frame: 3 * 3</caption>
+<thead>
+\t<tr><th scope=col>a</th><th scope=col>*</th><th scope=col>c</th></tr>
+\t<tr><th scope=col>&lt;int&gt;</th><th scope=col>*</th><th scope=col>&lt;int&gt;</th></tr>
+</thead>
+<tbody>
+\t<tr><td>1</td><td>*</td><td>7</td></tr>
+\t<tr><td>*</td><td>*</td><td>*</td></tr>
+\t<tr><td>3</td><td>*</td><td>9</td></tr>
+</tbody>
+</table>
+")
+})


### PR DESCRIPTION
Closes #177 